### PR TITLE
fix: move required hover effect to global stylesheet

### DIFF
--- a/styles/GameCard.module.css
+++ b/styles/GameCard.module.css
@@ -77,22 +77,6 @@
   overflow: hidden;
 }
 
-.gamecard {
-  display: flex;
-  flex: 1 1 100%;
-  width: 100%;
-  height: 100px;
-  background-color: var(--terciary-gray);
-  border-radius: var(--small-radius);
-  margin: 0.6rem;
-  transition: ease .3s;
-  cursor: pointer;
-}
-
-.gamecard:hover {
-  transform: scale(1.009);
-}
-
 .dropdown {
   display: flex;
   flex: 1 1 100%;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -161,6 +161,10 @@ transition: ease .3s;
 cursor: pointer;                                                                                                                                                                                                                    
 }                
 
+.gamecard:hover {
+  transform: scale(1.009);
+}
+
 .gamecard-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The current function for adding game cards on scroll does not support css modules with nextjs. No real issue other than a small part of the game card styling needs to be global.